### PR TITLE
Device ping

### DIFF
--- a/custom_components/rademacher/button.py
+++ b/custom_components/rademacher/button.py
@@ -61,6 +61,10 @@ class HomePilotPingButtonEntity(HomePilotEntity, ButtonEntity):
     def entity_registry_enabled_default(self):
         return False
 
+    @property
+    def available(self):
+        return True
+
     async def async_press(self) -> None:
         device: HomePilotDevice = self.coordinator.data[self.did]
         await device.async_ping()

--- a/custom_components/rademacher/manifest.json
+++ b/custom_components/rademacher/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "rademacher",
   "name": "Rademacher Homepilot",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "documentation": "https://github.com/peribeir/homeassistant-rademacher",
   "issue_tracker": "https://github.com/peribeir/homeassistant-rademacher/issues",
   "requirements": ["pyrademacher==0.6.9"],


### PR DESCRIPTION
Fixes #54
Ping buttons now stay active even if devices become unavailable, so that ping command can be sent to wake up devices.