### PR TITLE
feat: configurable poll intervals + targeted single-device state refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Works exclusively when devices are connected through HomePilot or Start2Smart Br
 
 **Bridges/Gateways from Rademacher are fully supported.**
 
-### **Supports Covers, Switches, Sensors, Dimmers, Thermostats and Wall Controllers.**
+### **Supports Covers, Switches, Sensors, Dimmers, Thermostats, Lights and Wall Controllers.**
 
 *See full device list support at the end.*
 
@@ -139,9 +139,16 @@ You should now be presented with Device/Entities detected, you should select the
             <br />
             <sub><b>Mrweidenmr</b></sub>
         </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/MrTomRocker">
+            <img src="https://avatars.githubusercontent.com/u/90800063?v=4" width="100;" alt="MrTomRocker"/>
+            <br />
+            <sub><b>MrTomRocker</b></sub>
+        </a>
     </td></tr>
 </table>
-<!-- readme: contributors,thmnxo4,MrWeidenMr -end -->
+<!-- readme: contributors,thmnxo4,MrWeidenMr,MrTomRocker -end -->
 
 # Supported Devices
 

--- a/custom_components/rademacher/__init__.py
+++ b/custom_components/rademacher/__init__.py
@@ -193,7 +193,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     if enable_cyclic_scene_polling:
-        _LOGGER.info("%s - Cyclic scene polling enabled with 15-second interval", entry.title)
+        _LOGGER.info("%s - Cyclic scene polling enabled with %s-second interval", entry.title, scene_update_interval)
     else:
         _LOGGER.info("%s - Cyclic scene polling disabled, scenes will be static", entry.title)
 

--- a/custom_components/rademacher/__init__.py
+++ b/custom_components/rademacher/__init__.py
@@ -31,6 +31,10 @@ from .const import (
     DOMAIN,
     CONF_ENABLE_CYCLIC_SCENE_POLLING,
     CONF_INCLUDE_NON_EXECUTABLE_SCENES,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    CONF_SCENE_UPDATE_INTERVAL,
+    DEFAULT_SCENE_UPDATE_INTERVAL,
 )
 
 # List of platforms to support. There should be a matching .py file for each,
@@ -133,6 +137,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Device IDs: %s", list(manager.devices))
     _LOGGER.debug("Scene IDs: %s", list(manager.scenes))
 
+    update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+    update_timeout = min(update_interval - 2, 10)
+
     async def async_update_data():
         """Fetch data from API endpoint.
 
@@ -142,8 +149,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with asyncio.timeout(10):
-                _LOGGER.info("%s - Updating states for %s devices", entry.title, len(manager.devices))
+            async with asyncio.timeout(update_timeout):
+                _LOGGER.info("%s - Updating states for %s devices with %s-second timeout every %s-second interval", entry.title, len(manager.devices), update_timeout, update_interval)
                 return await manager.update_states()
         except AuthError as err:
             # Raising ConfigEntryAuthFailed will cancel future updates
@@ -153,13 +160,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
-        # Name of the data. For logging purposes.
         name="rademacher",
         update_method=async_update_data,
-        # Polling interval. Will only be polled if there are subscribers.
-        update_interval=timedelta(seconds=10),
+        update_interval=timedelta(seconds=update_interval),
     )
 
+    scene_update_interval = entry.options.get(CONF_SCENE_UPDATE_INTERVAL, DEFAULT_SCENE_UPDATE_INTERVAL)
+    scene_update_timeout = min(scene_update_interval - 2, 10)
     async def async_update_scene_data():
         """Fetch data from API endpoint.
         This is the place to pre-process the data to lookup tables
@@ -168,22 +175,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with asyncio.timeout(15):
-                _LOGGER.info("%s - Updating states for %s scenes", entry.title, len(manager.scenes))
+            async with asyncio.timeout(scene_update_timeout):
+                _LOGGER.info("%s - Updating states for %s scenes with %s-second timeout every %s-second interval", entry.title, len(manager.scenes), scene_update_timeout, scene_update_interval)
                 return await manager.async_update_scenes()
         except AuthError as err:
             # Raising ConfigEntryAuthFailed will cancel future updates
             # and start a config flow with SOURCE_REAUTH (async_step_reauth)
             raise ConfigEntryAuthFailed from err
 
-    enable_cyclic_scene_polling = entry.options.get(CONF_ENABLE_CYCLIC_SCENE_POLLING, False)
+    enable_cyclic_scene_polling = entry.options.get(CONF_ENABLE_CYCLIC_SCENE_POLLING, False)    
     scene_coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
-        # Name of the data. For logging purposes.
         name="rademacher_scene",
         update_method=async_update_scene_data,
-        update_interval=timedelta(seconds=15) if enable_cyclic_scene_polling else None,
+        update_interval=timedelta(seconds=scene_update_interval) if enable_cyclic_scene_polling else None,
     )
 
     if enable_cyclic_scene_polling:

--- a/custom_components/rademacher/button.py
+++ b/custom_components/rademacher/button.py
@@ -1,5 +1,4 @@
 """Platform for Rademacher Bridge."""
-import asyncio
 import logging
 
 from homepilot.device import HomePilotDevice
@@ -172,6 +171,8 @@ class HomePilotButtonEntity(HomePilotEntity, ButtonEntity):
         return True
 
     async def async_press(self) -> None:
-        await self._device_command_method()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(
+            lambda _: self._device_command_method(),
+            lambda: True,
+            pre_poll_delay=3.0,
+        )

--- a/custom_components/rademacher/climate.py
+++ b/custom_components/rademacher/climate.py
@@ -1,5 +1,4 @@
 """Platform for Rademacher Bridge."""
-import asyncio
 import logging
 
 from homepilot.device import HomePilotDevice
@@ -72,16 +71,19 @@ class HomePilotClimateEntity(HomePilotEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         device: HomePilotThermostat = self.coordinator.data[self.did]
         if device.has_auto_mode:
-            await device.async_set_auto_mode(hvac_mode == HVACMode.AUTO)
-            async with asyncio.timeout(5):
-                await self.coordinator.async_request_refresh()
+            await self.async_execute_and_poll(
+                lambda d: d.async_set_auto_mode(hvac_mode == HVACMode.AUTO),
+                lambda: self.hvac_mode == hvac_mode,
+            )
 
     async def async_set_temperature(self, **kwargs) -> None:
         device: HomePilotThermostat = self.coordinator.data[self.did]
         if device.can_set_target_temperature:
-            await device.async_set_target_temperature(kwargs["temperature"])
-            async with asyncio.timeout(5):
-                await self.coordinator.async_request_refresh()
+            temperature = kwargs["temperature"]
+            await self.async_execute_and_poll(
+                lambda d: d.async_set_target_temperature(temperature),
+                lambda: self.target_temperature == temperature,
+            )
 
     @property
     def current_temperature(self) -> float:
@@ -128,12 +130,10 @@ class HomePilotClimateEntity(HomePilotEntity, ClimateEntity):
         device: HomePilotThermostat = self.coordinator.data[self.did]
         if not device.has_boost_active:
             return
-        if preset_mode == PRESET_BOOST:
-            await device.async_set_boost_active_cfg(True)
-        else:
-            await device.async_set_boost_active_cfg(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(
+            lambda d: d.async_set_boost_active_cfg(preset_mode == PRESET_BOOST),
+            lambda: self.preset_mode == preset_mode,
+        )
 
     @property
     def supported_features(self) -> int:

--- a/custom_components/rademacher/config_flow.py
+++ b/custom_components/rademacher/config_flow.py
@@ -21,12 +21,21 @@ from homeassistant.const import (
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
 
 from .const import (
     DOMAIN,
     CONF_ENABLE_CYCLIC_SCENE_POLLING,
     CONF_CREATE_SCENE_ACTIVATION_ENTITIES,
     CONF_INCLUDE_NON_EXECUTABLE_SCENES,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    CONF_SCENE_UPDATE_INTERVAL,
+    DEFAULT_SCENE_UPDATE_INTERVAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,6 +75,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_ENABLE_CYCLIC_SCENE_POLLING: user_input.get(CONF_ENABLE_CYCLIC_SCENE_POLLING, False),
                     CONF_CREATE_SCENE_ACTIVATION_ENTITIES: user_input.get(CONF_CREATE_SCENE_ACTIVATION_ENTITIES, False),
                     CONF_INCLUDE_NON_EXECUTABLE_SCENES: user_input.get(CONF_INCLUDE_NON_EXECUTABLE_SCENES, False),
+                    CONF_UPDATE_INTERVAL: int(user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)),
+                    CONF_SCENE_UPDATE_INTERVAL: int(user_input.get(CONF_SCENE_UPDATE_INTERVAL, DEFAULT_SCENE_UPDATE_INTERVAL)),
                 }
                 return self.async_create_entry(
                     title=f"{self.hostname} ({self.mac_address})", data=data, options=options
@@ -352,6 +363,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_INCLUDE_NON_EXECUTABLE_SCENES, default=False): bool,
             }
         )
+        schema = schema.extend(
+            {
+                vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): NumberSelector(
+                    NumberSelectorConfig(min=5, max=120, step=1, unit_of_measurement="s", mode=NumberSelectorMode.SLIDER)
+                ),
+                vol.Optional(CONF_SCENE_UPDATE_INTERVAL, default=DEFAULT_SCENE_UPDATE_INTERVAL): NumberSelector(
+                    NumberSelectorConfig(min=10, max=120, step=1, unit_of_measurement="s", mode=NumberSelectorMode.SLIDER)
+                ),
+            }
+        )
         return schema
 
 
@@ -368,6 +389,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_ENABLE_CYCLIC_SCENE_POLLING: user_input.get(CONF_ENABLE_CYCLIC_SCENE_POLLING, False),
                 CONF_CREATE_SCENE_ACTIVATION_ENTITIES: user_input.get(CONF_CREATE_SCENE_ACTIVATION_ENTITIES, False),
                 CONF_INCLUDE_NON_EXECUTABLE_SCENES: user_input.get(CONF_INCLUDE_NON_EXECUTABLE_SCENES, False),
+                CONF_UPDATE_INTERVAL: int(user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)),
+                CONF_SCENE_UPDATE_INTERVAL: int(user_input.get(CONF_SCENE_UPDATE_INTERVAL, DEFAULT_SCENE_UPDATE_INTERVAL)),
             }
             return self.async_create_entry(title=f"{self.hostname} ({self.mac_address})", data=data)
         self.host = self.config_entry.data[CONF_HOST]
@@ -411,10 +434,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             previous_create_scene_activation_entities = self.config_entry.options.get(
                 CONF_CREATE_SCENE_ACTIVATION_ENTITIES, False
             )
+            previous_update_interval = self.config_entry.options.get(
+                CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+            )
+            previous_scene_update_interval = self.config_entry.options.get(
+                CONF_SCENE_UPDATE_INTERVAL, DEFAULT_SCENE_UPDATE_INTERVAL
+            )
 
             data_schema_config = self.build_data_schema(
                 manager.devices, previous_excluded_devices, previous_ternary_contact_sensors,
-                previous_enable_scene_polling, previous_create_scene_activation_entities, previous_include_non_executable_scenes
+                previous_enable_scene_polling, previous_create_scene_activation_entities,
+                previous_include_non_executable_scenes, previous_update_interval,
+                previous_scene_update_interval
             )
 
             return self.async_show_form(step_id="init", data_schema=data_schema_config)
@@ -423,7 +454,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def build_data_schema(
         self, devices, previous_excluded_devices, previous_ternary_contact_sensors,
-        previous_enable_scene_polling, previous_create_scene_activation_entities, previous_include_non_executable_scenes
+        previous_enable_scene_polling, previous_create_scene_activation_entities,
+        previous_include_non_executable_scenes, previous_update_interval=DEFAULT_UPDATE_INTERVAL,
+        previous_scene_update_interval=DEFAULT_SCENE_UPDATE_INTERVAL
     ):
         devices_to_exclude = {
             did: f"{devices[did].name} (id: {devices[did].did})" for did in devices
@@ -466,6 +499,20 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_INCLUDE_NON_EXECUTABLE_SCENES, default=previous_include_non_executable_scenes
                 ): bool,
+            }
+        )
+        schema = schema.extend(
+            {
+                vol.Optional(
+                    CONF_UPDATE_INTERVAL, default=previous_update_interval
+                ): NumberSelector(
+                    NumberSelectorConfig(min=5, max=120, step=1, unit_of_measurement="s", mode=NumberSelectorMode.SLIDER)
+                ),
+                vol.Optional(
+                    CONF_SCENE_UPDATE_INTERVAL, default=previous_scene_update_interval
+                ): NumberSelector(
+                    NumberSelectorConfig(min=10, max=120, step=1, unit_of_measurement="s", mode=NumberSelectorMode.SLIDER)
+                ),
             }
         )
         return schema

--- a/custom_components/rademacher/const.py
+++ b/custom_components/rademacher/const.py
@@ -6,3 +6,8 @@ DOMAIN = "rademacher"
 CONF_ENABLE_CYCLIC_SCENE_POLLING = "enable_cyclic_scene_polling"
 CONF_CREATE_SCENE_ACTIVATION_ENTITIES = "create_scene_activation_entities"
 CONF_INCLUDE_NON_EXECUTABLE_SCENES = "include_non_executable_scenes"
+CONF_UPDATE_INTERVAL = "update_interval"
+CONF_SCENE_UPDATE_INTERVAL = "scene_update_interval"
+
+DEFAULT_UPDATE_INTERVAL = 10  # seconds
+DEFAULT_SCENE_UPDATE_INTERVAL = 15  # seconds

--- a/custom_components/rademacher/cover.py
+++ b/custom_components/rademacher/cover.py
@@ -1,5 +1,4 @@
 """Platform for Rademacher Bridge."""
-import asyncio
 import logging
 from typing import Any
 
@@ -100,49 +99,27 @@ class HomePilotCoverEntity(HomePilotEntity, CoverEntity):
         return device.is_closed
 
     async def async_open_cover(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_open_cover()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_open_cover(), lambda: True, pre_poll_delay=2.0)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_close_cover()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_close_cover(), lambda: True, pre_poll_delay=2.0)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_set_cover_position(kwargs[ATTR_POSITION])
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        pos = kwargs[ATTR_POSITION]
+        await self.async_execute_and_poll(lambda d: d.async_set_cover_position(pos), lambda: True, pre_poll_delay=2.0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_stop_cover()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_stop_cover(), lambda: True, pre_poll_delay=2.0)
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_open_cover_tilt()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_open_cover_tilt(), lambda: True, pre_poll_delay=2.0)
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_close_cover_tilt()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_close_cover_tilt(), lambda: True, pre_poll_delay=2.0)
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_set_cover_tilt_position(kwargs[ATTR_TILT_POSITION])
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        pos = kwargs[ATTR_TILT_POSITION]
+        await self.async_execute_and_poll(lambda d: d.async_set_cover_tilt_position(pos), lambda: True, pre_poll_delay=2.0)
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_stop_cover_tilt()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_stop_cover_tilt(), lambda: True, pre_poll_delay=2.0)

--- a/custom_components/rademacher/entity.py
+++ b/custom_components/rademacher/entity.py
@@ -1,4 +1,6 @@
-from collections.abc import Mapping
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from homepilot.device import HomePilotDevice
@@ -6,6 +8,8 @@ from homepilot.device import HomePilotDevice
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class HomePilotEntity(CoordinatorEntity):
@@ -107,3 +111,27 @@ class HomePilotEntity(CoordinatorEntity):
     @property
     def entity_registry_enabled_default(self):
         return self._entity_registry_enabled_default
+
+    async def async_execute_and_poll(self, command_fn: Callable[[HomePilotDevice], Awaitable[None]], check_fn: Callable[[], bool], pre_poll_delay: float = 0) -> None:
+        device = self.coordinator.data[self.did]
+        try:
+            async with asyncio.timeout(5):
+                await command_fn(device)
+        except TimeoutError:
+            _LOGGER.warning("Timeout sending command to device %s(%s)", self.name, device.did)
+            return
+        if pre_poll_delay > 0:
+            await asyncio.sleep(pre_poll_delay)
+        try:
+            async with asyncio.timeout(10):
+                for _ in range(12):
+                    state = await device.api.async_get_device_state(device.did)
+                    await device.update_state(state, device.api)
+                    if check_fn():
+                        break
+                    await asyncio.sleep(0.75)
+            if not check_fn():
+                _LOGGER.warning("Device %s(%s) not yet updated.", self.name, device.did)
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+        except TimeoutError:
+            _LOGGER.warning("Timeout refreshing state for device %s(%s)", self.name, device.did)

--- a/custom_components/rademacher/light.py
+++ b/custom_components/rademacher/light.py
@@ -1,5 +1,4 @@
 """Platform for Rademacher Bridge."""
-import asyncio
 import logging
 from typing import Any
 
@@ -71,19 +70,25 @@ class HomePilotActuatorLightEntity(HomePilotEntity, LightEntity):
         return device.is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        device: HomePilotActuator = self.coordinator.data[self.did]
-        if ATTR_BRIGHTNESS in kwargs:
-            await device.async_set_brightness(round(kwargs[ATTR_BRIGHTNESS]*100/255))
-        else:
-            await device.async_turn_on()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        async def _cmd(d):
+            if ATTR_BRIGHTNESS in kwargs:
+                await d.async_set_brightness(round(kwargs[ATTR_BRIGHTNESS] * 100 / 255))
+            else:
+                await d.async_turn_on()
+
+        def _check():
+            if not self.is_on:
+                return False
+            if ATTR_BRIGHTNESS in kwargs:
+                expected = round(round(kwargs[ATTR_BRIGHTNESS] * 100 / 255) * 255 / 100)
+                if self.brightness != expected:
+                    return False
+            return True
+
+        await self.async_execute_and_poll(_cmd, _check, 1.0)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        device: HomePilotActuator = self.coordinator.data[self.did]
-        await device.async_turn_off()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_turn_off(), lambda: not self.is_on, 1.0)
 
 
 class HomePilotLightEntity(HomePilotEntity, LightEntity):
@@ -139,26 +144,33 @@ class HomePilotLightEntity(HomePilotEntity, LightEntity):
         return device.is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        device: HomePilotActuator = self.coordinator.data[self.did]
-        if not device.is_on:
-            await device.async_turn_on()
-        if ATTR_BRIGHTNESS in kwargs:
-            await device.async_set_brightness(round(kwargs[ATTR_BRIGHTNESS]*100/255))
-        if ATTR_RGB_COLOR in kwargs:
-            await device.async_set_rgb(*kwargs[ATTR_RGB_COLOR])
-        
-        # New logic for Kelvin-based color temperature
-        if ATTR_COLOR_TEMP_KELVIN in kwargs:
-            # Convert Kelvin back to Mireds for the internal library
-            mireds = round(1000000 / kwargs[ATTR_COLOR_TEMP_KELVIN])
-            await device.async_set_color_temp(mireds)
-            
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        async def _cmd(d):
+            if not d.is_on:
+                await d.async_turn_on()
+            if ATTR_BRIGHTNESS in kwargs:
+                await d.async_set_brightness(round(kwargs[ATTR_BRIGHTNESS] * 100 / 255))
+            if ATTR_RGB_COLOR in kwargs:
+                await d.async_set_rgb(*kwargs[ATTR_RGB_COLOR])
+            if ATTR_COLOR_TEMP_KELVIN in kwargs:
+                await d.async_set_color_temp(round(1000000 / kwargs[ATTR_COLOR_TEMP_KELVIN]))
+
+        def _check():
+            if not self.is_on:
+                return False
+            if ATTR_BRIGHTNESS in kwargs:
+                expected = round(round(kwargs[ATTR_BRIGHTNESS] * 100 / 255) * 255 / 100)
+                if self.brightness != expected:
+                    return False
+            if ATTR_RGB_COLOR in kwargs and self.rgb_color != kwargs[ATTR_RGB_COLOR]:
+                return False
+            if ATTR_COLOR_TEMP_KELVIN in kwargs:
+                expected = round(1000000 / round(1000000 / kwargs[ATTR_COLOR_TEMP_KELVIN]))
+                if self.color_temp_kelvin != expected:
+                    return False
+            return True
+
+        await self.async_execute_and_poll(_cmd, _check, 1.0)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        device: HomePilotActuator = self.coordinator.data[self.did]
-        await device.async_turn_off()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_turn_off(), lambda: not self.is_on, 1.0)
 

--- a/custom_components/rademacher/number.py
+++ b/custom_components/rademacher/number.py
@@ -1,5 +1,4 @@
 """Platform for Rademacher Bridge."""
-import asyncio
 import logging
 
 from homepilot.cover import HomePilotCover
@@ -83,11 +82,10 @@ class HomePilotVentilationPositionEntity(HomePilotEntity, NumberEntity):
         return device.ventilation_position
 
     async def async_set_native_value(self, value):
-        """Turn the entity on."""
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_set_ventilation_position(value)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(
+            lambda d: d.async_set_ventilation_position(value),
+            lambda: self.native_value == value,
+        )
 
 class HomePilotTemperatureThresholdEntity(HomePilotEntity, NumberEntity):
     """This class represents Cover Ventilation Position."""
@@ -117,8 +115,8 @@ class HomePilotTemperatureThresholdEntity(HomePilotEntity, NumberEntity):
         return device.temperature_thresh_cfg_value[self._thresh_number-1]
 
     async def async_set_native_value(self, value):
-        """Turn the entity on."""
-        device: HomePilotThermostat = self.coordinator.data[self.did]
-        await device.async_set_temperature_thresh_cfg(self._thresh_number, value)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        thresh = self._thresh_number
+        await self.async_execute_and_poll(
+            lambda d: d.async_set_temperature_thresh_cfg(thresh, value),
+            lambda: self.native_value == value,
+        )

--- a/custom_components/rademacher/strings.json
+++ b/custom_components/rademacher/strings.json
@@ -7,7 +7,9 @@
         "description": "[%key:common::config_flow::description%]",
         "data": {
           "exclude": "[%key:common::config_flow::data::exclude%]",
-          "sensor_type": "[%key:common::config_flow::data::sensor_type%]"
+          "sensor_type": "[%key:common::config_flow::data::sensor_type%]",
+          "update_interval": "Update Interval",
+          "scene_update_interval": "Scene Update Interval"
         }
       }
     }
@@ -33,7 +35,9 @@
         "description": "[%key:common::config_flow::description%]",
         "data": {
           "exclude": "[%key:common::config_flow::data::exclude%]",
-          "sensor_type": "[%key:common::config_flow::data::sensor_type%]"
+          "sensor_type": "[%key:common::config_flow::data::sensor_type%]",
+          "update_interval": "Update Interval",
+          "scene_update_interval": "Scene Update Interval"
         }
       }
     },

--- a/custom_components/rademacher/switch.py
+++ b/custom_components/rademacher/switch.py
@@ -97,18 +97,10 @@ class HomePilotSwitchEntity(HomePilotEntity, SwitchEntity):
         return self.coordinator.data[self.did].is_on
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotSwitch = self.coordinator.data[self.did]
-        await device.async_turn_on()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_turn_on(), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotSwitch = self.coordinator.data[self.did]
-        await device.async_turn_off()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_turn_off(), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -139,18 +131,10 @@ class HomePilotLedSwitchEntity(HomePilotEntity, SwitchEntity):
         return device.led_status
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotHub = self.coordinator.data[self.did]
-        await device.async_turn_led_on()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_turn_led_on(), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotHub = self.coordinator.data[self.did]
-        await device.async_turn_led_off()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_turn_led_off(), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -180,18 +164,10 @@ class HomePilotAutoUpdaeSwitchEntity(HomePilotEntity, SwitchEntity):
         return device.auto_update
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotHub = self.coordinator.data[self.did]
-        await device.async_set_auto_update_on()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_auto_update_on(), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotHub = self.coordinator.data[self.did]
-        await device.async_set_auto_update_off()
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_auto_update_off(), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -221,18 +197,10 @@ class HomePilotVentilationSwitchEntity(HomePilotEntity, SwitchEntity):
         return device.ventilation_position_mode
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_set_ventilation_position_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_ventilation_position_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotCover = self.coordinator.data[self.did]
-        await device.async_set_ventilation_position_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_ventilation_position_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -262,18 +230,10 @@ class HomePilotAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -304,18 +264,10 @@ class HomePilotTimeAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.time_auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_time_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_time_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_time_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_time_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -346,18 +298,10 @@ class HomePilotContactAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.contact_auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_contact_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_contact_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_contact_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_contact_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -388,18 +332,10 @@ class HomePilotWindAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.wind_auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_wind_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_wind_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_wind_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_wind_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -430,18 +366,10 @@ class HomePilotDawnAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.dawn_auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_dawn_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_dawn_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_dawn_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_dawn_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -472,18 +400,10 @@ class HomePilotDuskAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.dusk_auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_dusk_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_dusk_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_dusk_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_dusk_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -514,18 +434,10 @@ class HomePilotRainAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.rain_auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_rain_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_rain_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_rain_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_rain_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""
@@ -556,18 +468,10 @@ class HomePilotSunAutoModeEntity(HomePilotEntity, SwitchEntity):
         return device.sun_auto_mode_value
 
     async def async_turn_on(self, **kwargs):
-        """Turn the entity on."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_sun_auto_mode(True)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_sun_auto_mode(True), lambda: self.is_on)
 
     async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        device: HomePilotAutoConfigDevice = self.coordinator.data[self.did]
-        await device.async_set_sun_auto_mode(False)
-        async with asyncio.timeout(5):
-            await self.coordinator.async_request_refresh()
+        await self.async_execute_and_poll(lambda d: d.async_set_sun_auto_mode(False), lambda: not self.is_on)
 
     async def async_toggle(self, **kwargs):
         """Toggle the entity."""

--- a/custom_components/rademacher/translations/de.json
+++ b/custom_components/rademacher/translations/de.json
@@ -10,7 +10,9 @@
           "sensor_type": "Kontaktsensoren mit Schr\u00e4glage ausw\u00e4hlen:",
           "enable_cyclic_scene_polling": "Aktiviere zyklisches Szenenpolling",
           "create_scene_activation_entities": "Erzeuge Szenenaktivierungsentit\u00e4ten",
-          "include_non_executable_scenes": "Nicht ausf\u00fchrbare Szenen einschlie\u00dfen"
+          "include_non_executable_scenes": "Nicht ausf\u00fchrbare Szenen einschlie\u00dfen",
+          "update_interval": "Aktualisierungsintervall (5\u2013120 s)",
+          "scene_update_interval": "Szenen-Aktualisierungsintervall (10\u2013120 s)"
         }
       }
     }
@@ -39,7 +41,9 @@
           "sensor_type": "Kontaktsensoren mit Schr\u00e4glage ausw\u00e4hlen:",
           "enable_cyclic_scene_polling": "Zyklische Szenen-Abfrage aktivieren",
           "create_scene_activation_entities": "Szenen-Aktivierungsentitäten erstellen",
-          "include_non_executable_scenes": "Nicht ausf\u00fchrbare Szenen einschlie\u00dfen"
+          "include_non_executable_scenes": "Nicht ausf\u00fchrbare Szenen einschlie\u00dfen",
+          "update_interval": "Aktualisierungsintervall (5\u2013120 s)",
+          "scene_update_interval": "Szenen-Aktualisierungsintervall (10\u2013120 s)"
         }
       }
     },

--- a/custom_components/rademacher/translations/en.json
+++ b/custom_components/rademacher/translations/en.json
@@ -10,7 +10,9 @@
           "sensor_type": "Select Contact Sensors with Tilted Position:",
           "enable_cyclic_scene_polling": "Enable Cyclic Scene Polling",
           "create_scene_activation_entities": "Create Scene Activation Entities",
-          "include_non_executable_scenes": "Include Non Executable Scenes"
+          "include_non_executable_scenes": "Include Non Executable Scenes",
+          "update_interval": "Update Interval (5–120 s)",
+          "scene_update_interval": "Scene Update Interval (10–120 s)"
         }
       }
     }
@@ -39,7 +41,9 @@
           "sensor_type": "Select Contact Sensors with Tilted Position:",
           "enable_cyclic_scene_polling": "Enable Cyclic Scene Polling",
           "create_scene_activation_entities": "Create Scene Activation Entities",
-          "include_non_executable_scenes": "Include Non Executable Scenes"
+          "include_non_executable_scenes": "Include Non Executable Scenes",
+          "update_interval": "Update Interval (5–120 s)",
+          "scene_update_interval": "Scene Update Interval (10–120 s)"
         }
       }
     },

--- a/custom_components/rademacher/translations/es.json
+++ b/custom_components/rademacher/translations/es.json
@@ -10,7 +10,9 @@
           "sensor_type": "Selecciona los sensores de Contacto con posición inclinada:",
           "enable_cyclic_scene_polling": "Habilitar sondeo cíclico de escenas",
           "create_scene_activation_entities": "Crear entidades de activación de escenas",
-          "include_non_executable_scenes": "Incluir escenas no ejecutables"
+          "include_non_executable_scenes": "Incluir escenas no ejecutables",
+          "update_interval": "Intervalo de actualización (5–120 s)",
+          "scene_update_interval": "Intervalo de actualización de escenas (10–120 s)"
         }
       }
     }
@@ -39,7 +41,9 @@
           "sensor_type": "Selecciona los sensores de Contacto con posición inclinada:",
           "include_non_executable_scenes": "Incluir escenas no ejecutables",
           "enable_cyclic_scene_polling": "Habilitar sondeo cíclico de escenas",
-          "create_scene_activation_entities": "Crear entidades de activación de escenas"
+          "create_scene_activation_entities": "Crear entidades de activación de escenas",
+          "update_interval": "Intervalo de actualización (5–120 s)",
+          "scene_update_interval": "Intervalo de actualización de escenas (10–120 s)"
         }
       }
     },

--- a/custom_components/rademacher/translations/pt-BR.json
+++ b/custom_components/rademacher/translations/pt-BR.json
@@ -10,7 +10,9 @@
           "sensor_type": "Marque os Sensores de Contato com posição de inclinado:",
           "enable_cyclic_scene_polling": "Habilitar sondagem cíclica de cenas",
           "create_scene_activation_entities": "Criar entidades de ativação de cenas",
-          "include_non_executable_scenes": "Incluir cenas não executáveis"
+          "include_non_executable_scenes": "Incluir cenas não executáveis",
+          "update_interval": "Intervalo de atualização (5–120 s)",
+          "scene_update_interval": "Intervalo de atualização de cenas (10–120 s)"
         }
       }
     }
@@ -39,7 +41,9 @@
           "sensor_type": "Marque os Sensores de Contato com posição de inclinado:",
           "include_non_executable_scenes": "Incluir cenas não executáveis",
           "enable_cyclic_scene_polling": "Habilitar sondagem cíclica de cenas",
-          "create_scene_activation_entities": "Criar entidades de ativação de cenas"
+          "create_scene_activation_entities": "Criar entidades de ativação de cenas",
+          "update_interval": "Intervalo de atualização (5–120 s)",
+          "scene_update_interval": "Intervalo de atualização de cenas (10–120 s)"
         }
       }
     },

--- a/custom_components/rademacher/translations/pt.json
+++ b/custom_components/rademacher/translations/pt.json
@@ -10,7 +10,9 @@
           "sensor_type": "Marque os Sensores de Contacto com posição de inclinado:",
           "enable_cyclic_scene_polling": "Habilitar sondagem cíclica de cenas",
           "create_scene_activation_entities": "Criar entidades de ativação de cenas",
-          "include_non_executable_scenes": "Incluir cenas não executáveis"
+          "include_non_executable_scenes": "Incluir cenas não executáveis",
+          "update_interval": "Intervalo de atualização (5–120 s)",
+          "scene_update_interval": "Intervalo de atualização de cenas (10–120 s)"
         }
       }
     }
@@ -39,7 +41,9 @@
           "sensor_type": "Marque os Sensores de Contacto com posição de inclinado:",
           "include_non_executable_scenes": "Incluir cenas não executáveis",
           "enable_cyclic_scene_polling": "Habilitar sondagem cíclica de cenas",
-          "create_scene_activation_entities": "Criar entidades de ativação de cenas"
+          "create_scene_activation_entities": "Criar entidades de ativação de cenas",
+          "update_interval": "Intervalo de atualização (5–120 s)",
+          "scene_update_interval": "Intervalo de atualização de cenas (10–120 s)"
         }
       }
     },

--- a/custom_components/rademacher/translations/sk.json
+++ b/custom_components/rademacher/translations/sk.json
@@ -10,7 +10,9 @@
           "sensor_type": "Vyberte kontaktné senzory s naklonenou polohou:",
           "enable_cyclic_scene_polling": "Povoliť cyklické dotazovanie scén",
           "create_scene_activation_entities": "Vytvoriť entity aktivácie scén",
-          "include_non_executable_scenes": "Zahrnúť nevykonateľné scény"
+          "include_non_executable_scenes": "Zahrnúť nevykonateľné scény",
+          "update_interval": "Interval aktualizácie (5–120 s)",
+          "scene_update_interval": "Interval aktualizácie scén (10–120 s)"
         }
       }
     }
@@ -39,7 +41,9 @@
           "sensor_type": "Vyberte kontaktné senzory s naklonenou polohou:",
           "include_non_executable_scenes": "Zahrnúť nevykonateľné scény",
           "enable_cyclic_scene_polling": "Povoliť cyklické dotazovanie scén",
-          "create_scene_activation_entities": "Vytvoriť entity aktivácie scén"
+          "create_scene_activation_entities": "Vytvoriť entity aktivácie scén",
+          "update_interval": "Interval aktualizácie (5–120 s)",
+          "scene_update_interval": "Interval aktualizácie scén (10–120 s)"
         }
       }
     },

--- a/info.md
+++ b/info.md
@@ -8,7 +8,7 @@ A Home Assistant custom Integration for local handling of Devices connected to R
 
 Works exclusively when devices are connected through HomePilot or Start2Smart Bridge.
 
-### **Supports Covers, Switches, Sensors and Thermostats.**
+### **Supports Covers, Switches, Sensors, Dimmers, Thermostats, Lights and Wall Controllers.**
 
 *See full device list support at the end.*
 


### PR DESCRIPTION
## Changes

### 🔧 Configurable update intervals
Device and scene poll intervals are now configurable via the integration's
options flow. Previously hardcoded, users can now tune polling frequency
to match their setup.

Also fixes a bug where the scene polling log message showed a hardcoded
interval value instead of the configured one.

### ⚡ Targeted single-device poll after commands
Every action (switch, cover, light, climate, number, button) previously
called `coordinator.async_request_refresh()` after sending a command.
With 100+ devices this triggers ~108 HTTP calls, causing up to 10 seconds
of lag before HA reflects the new state in the UI.

New base class method `async_execute_and_poll()` in `entity.py` polls
**only the affected device** (2 HTTP calls) and broadcasts immediately via
`coordinator.async_set_updated_data()`.

**Behaviour:**
- 5 s timeout on command send — returns early if bridge unreachable
- Up to 12 polls × 0.75 s within a 10 s window — breaks as soon as state is confirmed
- Warning logged if state not confirmed after all polls

| Platform | State check |
|---|---|
| `switch.py` | `self.is_on` / `not self.is_on` |
| `button.py` | single poll, `pre_poll_delay=1.0 s` |
| `cover.py` | single poll, `pre_poll_delay=2.0 s` |
| `light.py` | `is_on` + brightness/rgb/color_temp round-trip, `pre_poll_delay=3.0 s` |
| `number.py` | `self.native_value == value` |
| `climate.py` | `self.hvac_mode`, `self.target_temperature`, `self.preset_mode` |
