### PR TITLE
Feat/auto config device commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ When configuring the Rademacher Bridge integration, either during the initial se
 | **Include Non Executable Scenes** | `include_non_executable_scenes` | If enabled, scenes registered on the bridge that are marked as non-executable will also be imported. | Boolean | `false` |
 | **Create Inverted Cover Position Sensors** | `create_inverted_cover_position` | If enabled, dedicated diagnostic sensor entities will be created to report the inverted cover and tilt position to match actual Rademacher bridge behavior. NOTE: If you disable this flag, you will need to manually delete the previously created entities so be careful when enabling it. | Boolean | `false` |
 
+# Automatic Modes, Command Buttons & Program-Active Sensors
+
+Many Rademacher devices (covers, switches/actuators, thermostats, …) can react automatically to environmental events (sun, wind, rain, dawn, dusk, time, contact). Where a device exposes them, the integration creates:
+
+- **Auto-mode switches** – `Auto Mode` plus per-function switches (`Sun`/`Wind`/`Rain`/`Dawn`/`Dusk`/`Time`/`Contact Auto Mode`) to turn each automatic function on or off. On thermostats the general auto mode is represented as the climate entity's HVAC mode instead of a switch.
+- **Command buttons** – `Sun`/`Wind`/`Rain Start`/`Stop`, `Goto Dawn`/`Dusk Position`, `Contact Open`/`Close`. They trigger the matching command once and are **disabled by default** (enable them per entity if needed). A command button is only *available* while its matching auto-mode switch is on, and always available when the device has no such switch.
+- **Program-active sensors** – binary sensors (`Sun`/`Wind`/`Rain Program Active`) reporting whether the respective automatic program is currently running.
+
+> **Note:** This integration maps the Rademacher devices together with the specific HomePilot/Start2Smart bridge in use and mirrors exactly what that bridge reports through its API. Which of the entities above are created — and how they behave — therefore depends on the individual device and the used bridge.
+
 # Direct and Indirect Contributors
 
 <!-- readme: contributors,thmnxo4,MrWeidenMr,fritte87 -start -->

--- a/custom_components/rademacher/binary_sensor.py
+++ b/custom_components/rademacher/binary_sensor.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import logging
 
 from homepilot.cover import HomePilotCover
-from homepilot.device import HomePilotDevice
+from homepilot.device import HomePilotDevice, HomePilotAutoConfigDevice
 from homepilot.manager import HomePilotManager
 from homepilot.sensor import HomePilotSensor
 from homepilot.wallcontroller import HomePilotWallController
@@ -153,6 +153,9 @@ async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_entities)
                             entity_category=EntityCategory.DIAGNOSTIC,
                         )
                     )
+            # Weather program "active" sensors are provided by any auto config
+            # device that advertises the corresponding *_PROG_ACTIVE_EVT event.
+            if isinstance(device, HomePilotAutoConfigDevice):
                 if device.has_rain_prog_active:
                     _LOGGER.info(
                         "Found Rain Program Active Sensor for Device ID: %s", device.did

--- a/custom_components/rademacher/button.py
+++ b/custom_components/rademacher/button.py
@@ -1,10 +1,8 @@
 """Platform for Rademacher Bridge."""
 import logging
 
-from homepilot.device import HomePilotDevice
-from homepilot.thermostat import HomePilotThermostat
+from homepilot.device import HomePilotDevice, HomePilotAutoConfigDevice
 from homepilot.manager import HomePilotManager
-from homepilot.cover import HomePilotCover
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import CONF_EXCLUDE
@@ -38,7 +36,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     entity_registry_enabled_default=False,
                     entity_category=EntityCategory.DIAGNOSTIC,
                 ))
-            if isinstance(device, HomePilotThermostat):
+            # Weather/contact command buttons are exposed by any auto config
+            # device (cover, switch/actuator, thermostat) advertising the
+            # corresponding command capability, not only covers/thermostats.
+            if isinstance(device, HomePilotAutoConfigDevice):
                 if device.has_contact_open_cmd:
                     _LOGGER.info("Found Contact Open Command Button for Device ID: %s", device.did)
                     new_entities.append(HomePilotButtonEntity(
@@ -48,6 +49,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Contact Open",
                         device_command_method=device.async_contact_open_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_contact_auto_mode,
+                        auto_mode_value=lambda d: d.contact_auto_mode_value,
                     ))
                 if device.has_contact_close_cmd:
                     _LOGGER.info("Found Contact Close Command Button for Device ID: %s", device.did)
@@ -58,8 +61,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Contact Close",
                         device_command_method=device.async_contact_close_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_contact_auto_mode,
+                        auto_mode_value=lambda d: d.contact_auto_mode_value,
                     ))
-            if isinstance(device, HomePilotCover):
                 if device.has_sun_start_cmd:
                     _LOGGER.info("Found Sun Start Command Button for Device ID: %s", device.did)
                     new_entities.append(HomePilotButtonEntity(
@@ -69,6 +73,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Sun Start",
                         device_command_method=device.async_sun_start_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_sun_auto_mode,
+                        auto_mode_value=lambda d: d.sun_auto_mode_value,
                     ))
                 if device.has_sun_stop_cmd:
                     _LOGGER.info("Found Sun Stop Command Button for Device ID: %s", device.did)
@@ -79,6 +85,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Sun Stop",
                         device_command_method=device.async_sun_stop_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_sun_auto_mode,
+                        auto_mode_value=lambda d: d.sun_auto_mode_value,
                     ))
                 if device.has_wind_start_cmd:
                     _LOGGER.info("Found Wind Start Command Button for Device ID: %s", device.did)
@@ -89,6 +97,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Wind Start",
                         device_command_method=device.async_wind_start_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_wind_auto_mode,
+                        auto_mode_value=lambda d: d.wind_auto_mode_value,
                     ))
                 if device.has_wind_stop_cmd:
                     _LOGGER.info("Found Wind Stop Command Button for Device ID: %s", device.did)
@@ -99,6 +109,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Wind Stop",
                         device_command_method=device.async_wind_stop_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_wind_auto_mode,
+                        auto_mode_value=lambda d: d.wind_auto_mode_value,
                     ))
                 if device.has_rain_start_cmd:
                     _LOGGER.info("Found Rain Start Command Button for Device ID: %s", device.did)
@@ -109,6 +121,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Rain Start",
                         device_command_method=device.async_rain_start_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_rain_auto_mode,
+                        auto_mode_value=lambda d: d.rain_auto_mode_value,
                     ))
                 if device.has_rain_stop_cmd:
                     _LOGGER.info("Found Rain Stop Command Button for Device ID: %s", device.did)
@@ -119,6 +133,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Rain Stop",
                         device_command_method=device.async_rain_stop_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_rain_auto_mode,
+                        auto_mode_value=lambda d: d.rain_auto_mode_value,
                     ))
                 if device.has_goto_dawn_pos_cmd:
                     _LOGGER.info("Found Goto Dawn Position Command Button for Device ID: %s", device.did)
@@ -129,6 +145,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Goto Dawn Position",
                         device_command_method=device.async_goto_dawn_pos_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_dawn_auto_mode,
+                        auto_mode_value=lambda d: d.dawn_auto_mode_value,
                     ))
                 if device.has_goto_dusk_pos_cmd:
                     _LOGGER.info("Found Goto Dusk Position Command Button for Device ID: %s", device.did)
@@ -139,6 +157,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         name_suffix="Goto Dusk Position",
                         device_command_method=device.async_goto_dusk_pos_cmd,
                         entity_registry_enabled_default=False,
+                        auto_mode_has=lambda d: d.has_dusk_auto_mode,
+                        auto_mode_value=lambda d: d.dusk_auto_mode_value,
                     ))
     if new_entities:
         async_add_entities(new_entities)
@@ -155,6 +175,8 @@ class HomePilotButtonEntity(HomePilotEntity, ButtonEntity):
         device_command_method,
         entity_category=None,
         entity_registry_enabled_default=False,
+        auto_mode_has=None,
+        auto_mode_value=None,
     ) -> None:
         super().__init__(
             coordinator,
@@ -165,10 +187,20 @@ class HomePilotButtonEntity(HomePilotEntity, ButtonEntity):
             entity_registry_enabled_default=entity_registry_enabled_default,
         )
         self._device_command_method = device_command_method
+        self._auto_mode_has = auto_mode_has
+        self._auto_mode_value = auto_mode_value
 
     @property
     def available(self):
-        return True
+        # Buttons without an associated auto mode (e.g. ping) are always available.
+        if self._auto_mode_has is None:
+            return True
+        device: HomePilotDevice = self.coordinator.data[self.did]
+        # If the device exposes no auto mode switch for this event, the button is
+        # always available; otherwise it is only available while that switch is on.
+        if not self._auto_mode_has(device):
+            return True
+        return self._auto_mode_value(device)
 
     async def async_press(self) -> None:
         await self.async_execute_and_poll(

--- a/custom_components/rademacher/manifest.json
+++ b/custom_components/rademacher/manifest.json
@@ -18,8 +18,8 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/peribeir/homeassistant-rademacher/issues",
   "requirements": [
-    "pyrademacher==0.15.0",
+    "pyrademacher==0.16.0",
     "asyncio>=3.4.3"
   ],
-  "version": "2.4.1-beta.5"
+  "version": "2.4.1-beta.6"
 }


### PR DESCRIPTION
# PR: expose command buttons and program-active sensors for all device types

_Repo:_ homeassistant-rademacher · _Branch:_ `feat/auto-config-device-commands` · _Base:_ `master`
_Companion library PR:_ MrTomRocker/pyrademacher `feat/auto-config-device-commands` (**v0.16.0**)

## Summary

The weather/contact **command buttons** (sun/wind/rain start–stop, goto dawn/dusk position, contact open/close) were only created for covers and thermostats, and the sun/wind/rain **program-active binary sensors** only for covers — even though other Rademacher devices (universal / switch / wall-controller actuators, dimmers) advertise the very same capabilities through the bridge API.

This PR creates these entities based on each device's **reported capabilities** instead of its device class, so every applicable device exposes them.

## Changes

- **`button.py`** – command buttons are now created for any `HomePilotAutoConfigDevice` that reports the matching `has_*_cmd` capability (previously gated on `HomePilotCover` / `HomePilotThermostat`). Each button's `available` state follows its corresponding auto-mode switch: available only while that mode is on, and always available when the device has no such switch. Buttons remain **disabled by default**.
- **`binary_sensor.py`** – the sun/wind/rain *program-active* sensors are now created for any `HomePilotAutoConfigDevice` reporting the `*_PROG_ACTIVE_EVT` event (previously gated on `HomePilotCover`). Enabled by default, as before.
- **`manifest.json`** – requires `pyrademacher==0.16.0`; version bumped to `2.4.1-beta.6`.
- **`README.md`** – new section documenting auto modes, command buttons and program-active sensors.

## Behavior change (minor)

This is a small, mostly additive behavior change for existing installations:

- On devices that advertise the capabilities, the new **program-active sensors are enabled by default** and appear automatically after the update; the new **command buttons are disabled by default** (opt-in per entity).
- Command buttons now have an `available` state tied to their auto mode — a button is only available while its corresponding auto-mode switch is on (and always available when the device has no such switch). Previously command buttons were always available, so existing cover buttons may now show as unavailable while the matching automatic mode is off.

## Related issues

- **Partially addresses #174** (*Dawn and dusk without window status check*): the `Goto Dawn/Dusk Position` buttons are now unavailable while their corresponding auto mode (`Dawn`/`Dusk Auto Mode`) is off, so they can no longer be triggered from Home Assistant when that automation is disabled — which covers the "moves even when automations are disabled" part of the report. The window-open safety check itself is device/motor-level and is **not** part of this change.

## Dependency

Requires the companion library change, where the command and program-active capabilities were moved into the shared `HomePilotAutoConfigDevice` base class: **pyrademacher 0.16.0** (`feat/auto-config-device-commands`). That needs to be available/released first.

## Note on device/bridge variability

The integration maps the Rademacher devices together with the specific HomePilot/Start2Smart bridge in use and mirrors exactly what that bridge reports through its API. The set of created entities therefore depends on the individual device and the used bridge.

## Testing

Validated on a live HomePilot setup — **2 bridges, ~94 Rademacher devices** — covering covers, tubular-motor actuators, universal / switch / wall-controller actuators, dimmers and thermostats.

After deployment the command buttons and program-active sensors correctly appear on the **non-cover devices** that advertise the capabilities (e.g. a *Universal actuator 2-channel* used as an awning now exposes the Sun/Wind/Rain program-active sensors and the weather/goto/contact buttons) — these devices previously exposed none. Existing cover/thermostat entities are unchanged, and no setup errors were observed.

Library side: full pyrademacher test suite green (142 passed) incl. new tests for the base-class command + program-active plumbing; flake8 (E9,F63,F7,F82) clean.
