### PR TITLE
fix: keep scene id as native int so coordinator lookup matches (#176)

### DIFF
--- a/custom_components/rademacher/entity.py
+++ b/custom_components/rademacher/entity.py
@@ -31,7 +31,7 @@ class HomePilotEntity(CoordinatorEntity):
         self._device_class = device_class
         self._entity_category = entity_category
         self._icon = icon
-        self._did = str(device.did)
+        self._did = device.did
         self._model = device.model
         self._entity_registry_enabled_default = entity_registry_enabled_default
 

--- a/custom_components/rademacher/manifest.json
+++ b/custom_components/rademacher/manifest.json
@@ -18,8 +18,8 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/peribeir/homeassistant-rademacher/issues",
   "requirements": [
-    "pyrademacher==0.16.0",
+    "pyrademacher==0.17.0",
     "asyncio>=3.4.3"
   ],
-  "version": "2.4.2"
+  "version": "2.4.3"
 }

--- a/custom_components/rademacher/scene.py
+++ b/custom_components/rademacher/scene.py
@@ -41,7 +41,7 @@ class HomePilotSceneEntity(CoordinatorEntity, Scene):
         CoordinatorEntity.__init__(self, coordinator)
         Scene.__init__(self)
 
-        self._sid = str(scene.sid)
+        self._sid = scene.sid
         # Use hub MAC + scene sid for globally unique ID, similar to device entities
         hub_mac = coordinator.config_entry.unique_id or "unknown"
         self._attr_unique_id = f"{hub_mac}_scene_{scene.sid}"

--- a/custom_components/rademacher/switch.py
+++ b/custom_components/rademacher/switch.py
@@ -488,7 +488,7 @@ class HomePilotRademacherSceneEnabledEntity(CoordinatorEntity, SwitchEntity):
         self, coordinator: DataUpdateCoordinator, scene: HomePilotScene, entity_registry_enabled_default=False
     ) -> None:
         super().__init__(coordinator)
-        self._sid = str(scene.sid)
+        self._sid = scene.sid
         hub_mac = coordinator.config_entry.unique_id or "unknown"
         self._unique_id = f"{hub_mac}_{scene.sid}_scene_enabled"
         self._name = f"{scene.name} Enabled"


### PR DESCRIPTION
# Fix #176: scene entities enabled but unavailable (scene id key-type mismatch)

_Repo:_ homeassistant-rademacher · _Base:_ `master` · **Fixes #176**

> Requires **pyrademacher 0.17.0** (peribeir/pyrademacher#71) — this PR bumps the
> requirement. That library change must be released to PyPI before this is merged.

## Summary

Since v2.4.2, HomePilot **scene** entities are created but stay `unavailable` and cannot be triggered (and the log shows repeated `Error adding entity None for domain scene with platform rademacher` at startup). v2.4.1 worked.

Root cause is a **key-type mismatch** introduced in commit `1d2ea04` ("refactor: standardize IDs as strings…"):

- The scene coordinator's data is `manager.scenes`, which the library keyed by `scene["id"]` — an **`int`** (it comes from the raw scenes-API JSON field `id`).
- The refactor changed the entity side to `self._sid = str(scene.sid)`, so every lookup became `self.coordinator.data["11"]` (str) against a dict keyed by `11` (int) → **`KeyError`**.
- `available` catches it and returns `False` (→ "unavailable"); the other property accessors (`is_enabled`, `icon`, `extra_state_attributes`) don't, so they raise while HA adds the entity (→ "Error adding entity None").

The mismatch is rooted in the bridge API itself, which serializes ids **inconsistently across its endpoints**:

```jsonc
// /devices  → ids come as capability values, which are always strings
{ "name": "ID_DEVICE_LOC", "value": "1" }         // device.did -> "1"  (str)

// /scenes   → the top-level id is a raw JSON number
{ "id": 8001, "name": "heizung absenken", ... }   // scene.sid  -> 8001 (int)

// /v4/devices (get_visible_devices, used only for state polling)
{ "did": 2, ... }                                 // the SAME kind of device id, here an int
```

The library keyed `manager.devices` off `/devices`, so `device.did` is a `str`, while `scene.sid` (from `/scenes`) was an `int`. The integration's blanket `str(...)` was therefore a no-op for devices but a breaking change for scenes. (The `/v4/devices` int `did` is only used for state polling, not for keying — but it shows why a uniform `str()` on ids is fragile against this API.)

### Why only scenes broke (and not devices)

The same `str()` was applied uniformly, including `self._did = str(device.did)` in `entity.py`. That one was **harmless**, because `device.did` is **already a `str`** at runtime: it comes from a capability value (`device_map[APICAP_ID_DEVICE_LOC]["value"]`), and capability values are JSON strings (e.g. `"21"`). So `manager.devices` is **str-keyed** and `str(device.did)` is a no-op.

Scene ids were the exception: `scene.sid = scene_data["id"]` is a raw JSON **number** → `int`, and `manager.scenes` was **int-keyed**. So the same `str()` that is a no-op for devices was a breaking change for scenes.

## Fix

The proper long-term fix is to make ids consistently `str` end-to-end, which is done in the library (**pyrademacher 0.17.0**): the API layer normalizes scene ids to `str` on read, so `scene.sid` is a `str` and `manager.scenes` is **str-keyed**, just like devices.

With that, the integration uses the scene id **natively** and the lookup matches again:

- `scene.py` → `HomePilotSceneEntity`: `self._sid = scene.sid` (was `str(scene.sid)`)
- `switch.py` → `HomePilotRademacherSceneEnabledEntity`: `self._sid = scene.sid` (was `str(scene.sid)`)
- `entity.py` → `HomePilotEntity`: `self._did = device.did` (drops the no-op `str(device.did)`)
- `manifest.json`: requirement bumped to `pyrademacher==0.17.0`, version `2.4.3`

`unique_id` is derived directly from `scene.sid` and is unchanged (`str(int) == "1"`) → **no entity-registry migration** is needed; existing (currently-unavailable) scene entities simply become available again after the update.

## Companion change — pyrademacher 0.17.0 (peribeir/pyrademacher#71)

The library PR (**peribeir/pyrademacher#71**) fixes the inconsistency at its source and the misleading annotations:

1. **Scene ids normalized to `str`** at the API layer (`async_get_scenes`/`_v4`), so `scene.sid` and `manager.scenes` keys are `str` — consistent with device ids.
2. **Annotations corrected to match runtime** (`did: str` across all device classes; `_sid: str`), since `did` was always a `str` at runtime despite being declared `int`.

This realizes the original "IDs as strings" intent properly — ids are now `str` everywhere, end-to-end, instead of being stringified only at the entity boundary.

## Testing

- **Live**: deployed to a HomePilot setup (pyrademacher 0.17.0 + this integration). The `Error adding entity None for domain scene` count went from **14 → 0** after restart, and the scene entities are available and triggerable again.
- **Compatibility**: verified the integration against the 0.17.0 types — str scene ids (str-keyed coordinator lookup), and unchanged `unique_id` (no migration).
